### PR TITLE
Improved tests

### DIFF
--- a/Tests/FireworkTests/HTTPClientTests.swift
+++ b/Tests/FireworkTests/HTTPClientTests.swift
@@ -86,8 +86,8 @@ final class HTTPClientTests: XCTestCase {
         
         do {
             let data = try await httpClient.send(SampleGETRequest())
-            let unwrapedData = try XCTUnwrap(data)
-            XCTAssertEqual(String(decoding: unwrapedData, as: UTF8.self), "dummy")
+            let unwrappedData = try XCTUnwrap(data)
+            XCTAssertEqual(String(decoding: unwrappedData, as: UTF8.self), "dummy")
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/Tests/FireworkTests/HTTPClientTests.swift
+++ b/Tests/FireworkTests/HTTPClientTests.swift
@@ -77,10 +77,8 @@ final class HTTPClientTests: XCTestCase {
         }
     }
     
-    func testSendingGETRequestAsync_success() async throws {
-        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) else {
-            throw XCTSkip("This test can only run on iOS 13.0+, macOS 10.15+, tvOS 13.0+ or watchOS 6.0+")
-        }
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testSendingGETRequestAsync_success() async {
         let httpClient = HTTPClient(adaptor: StubAdaptor(result: .success(Data("dummy".utf8))))
         assert(httpClient.adaptor.calledCount == 0)
         
@@ -94,10 +92,8 @@ final class HTTPClientTests: XCTestCase {
         XCTAssertEqual(httpClient.adaptor.calledCount, 1)
     }
     
-    func testSendingGETRequestAsync_failure() async throws {
-        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) else {
-            throw XCTSkip("This test can only run on iOS 13.0+, macOS 10.15+, tvOS 13.0+ or watchOS 6.0+")
-        }
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testSendingGETRequestAsync_failure() async {
         let httpClient = HTTPClient(adaptor: StubAdaptor(result: .failure(SampleError())))
         assert(httpClient.adaptor.calledCount == 0)
         
@@ -254,10 +250,8 @@ final class HTTPClientTests: XCTestCase {
         }
     }
     
-    func testSendingAndDecodingAsync_success() async throws {
-        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) else {
-            throw XCTSkip("This test can only run on iOS 13.0+, macOS 10.15+, tvOS 13.0+ or watchOS 6.0+")
-        }
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testSendingAndDecodingAsync_success() async {
         let httpClient = HTTPClient(adaptor: StubAdaptor(result: .success(Data(camelCaseJSON.utf8))))
         assert(httpClient.adaptor.calledCount == 0)
         
@@ -270,10 +264,8 @@ final class HTTPClientTests: XCTestCase {
         XCTAssertEqual(httpClient.adaptor.calledCount, 1)
     }
     
-    func testSendingAndDecodingAsync_decodingFailure() async throws {
-        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) else {
-            throw XCTSkip("This test can only run on iOS 13.0+, macOS 10.15+, tvOS 13.0+ or watchOS 6.0+")
-        }
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testSendingAndDecodingAsync_decodingFailure() async {
         let httpClient = HTTPClient(adaptor: StubAdaptor(result: .success(Data(invalidKeyJSON.utf8))))
         assert(httpClient.adaptor.calledCount == 0)
         
@@ -288,10 +280,8 @@ final class HTTPClientTests: XCTestCase {
         XCTAssertEqual(httpClient.adaptor.calledCount, 1)
     }
     
-    func testSendingAndDecodingAsync_requestFailure() async throws {
-        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) else {
-            throw XCTSkip("This test can only run on iOS 13.0+, macOS 10.15+, tvOS 13.0+ or watchOS 6.0+")
-        }
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testSendingAndDecodingAsync_requestFailure() async {
         let httpClient = HTTPClient(adaptor: StubAdaptor(result: .failure(SampleError())))
         assert(httpClient.adaptor.calledCount == 0)
         

--- a/Tests/FireworkTests/HTTPClientTests.swift
+++ b/Tests/FireworkTests/HTTPClientTests.swift
@@ -133,21 +133,15 @@ final class HTTPClientTests: XCTestCase {
     }
     
     private var camelCaseJSON: String {
-        """
-        { "someProperty": "some property" }
-        """
+        #"{ "someProperty": "some property" }"#
     }
     
     private var snakeCaseJSON: String {
-        """
-        { "some_property": "some property" }
-        """
+        #"{ "some_property": "some property" }"#
     }
     
     private var invalidKeyJSON: String {
-        """
-        { "id": 10 }
-        """
+        #"{ "id": 10 }"#
     }
     
     func testSendingAndDecoding() {

--- a/Tests/FireworkTests/HTTPClientTests.swift
+++ b/Tests/FireworkTests/HTTPClientTests.swift
@@ -77,8 +77,10 @@ final class HTTPClientTests: XCTestCase {
         }
     }
     
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-    func testSendingGETRequestAsync_success() async {
+    func testSendingGETRequestAsync_success() async throws {
+        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) else {
+            throw XCTSkip("This test can only run on iOS 13.0+, macOS 10.15+, tvOS 13.0+ or watchOS 6.0+")
+        }
         let httpClient = HTTPClient(adaptor: StubAdaptor(result: .success(Data("dummy".utf8))))
         assert(httpClient.adaptor.calledCount == 0)
         
@@ -92,8 +94,10 @@ final class HTTPClientTests: XCTestCase {
         XCTAssertEqual(httpClient.adaptor.calledCount, 1)
     }
     
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-    func testSendingGETRequestAsync_failure() async {
+    func testSendingGETRequestAsync_failure() async throws {
+        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) else {
+            throw XCTSkip("This test can only run on iOS 13.0+, macOS 10.15+, tvOS 13.0+ or watchOS 6.0+")
+        }
         let httpClient = HTTPClient(adaptor: StubAdaptor(result: .failure(SampleError())))
         assert(httpClient.adaptor.calledCount == 0)
         
@@ -256,8 +260,10 @@ final class HTTPClientTests: XCTestCase {
         }
     }
     
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-    func testSendingAndDecodingAsync_success() async {
+    func testSendingAndDecodingAsync_success() async throws {
+        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) else {
+            throw XCTSkip("This test can only run on iOS 13.0+, macOS 10.15+, tvOS 13.0+ or watchOS 6.0+")
+        }
         let httpClient = HTTPClient(adaptor: StubAdaptor(result: .success(Data(camelCaseJSON.utf8))))
         assert(httpClient.adaptor.calledCount == 0)
         
@@ -270,8 +276,10 @@ final class HTTPClientTests: XCTestCase {
         XCTAssertEqual(httpClient.adaptor.calledCount, 1)
     }
     
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-    func testSendingAndDecodingAsync_decodingFailure() async {
+    func testSendingAndDecodingAsync_decodingFailure() async throws {
+        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) else {
+            throw XCTSkip("This test can only run on iOS 13.0+, macOS 10.15+, tvOS 13.0+ or watchOS 6.0+")
+        }
         let httpClient = HTTPClient(adaptor: StubAdaptor(result: .success(Data(invalidKeyJSON.utf8))))
         assert(httpClient.adaptor.calledCount == 0)
         
@@ -286,8 +294,10 @@ final class HTTPClientTests: XCTestCase {
         XCTAssertEqual(httpClient.adaptor.calledCount, 1)
     }
     
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-    func testSendingAndDecodingAsync_requestFailure() async {
+    func testSendingAndDecodingAsync_requestFailure() async throws {
+        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) else {
+            throw XCTSkip("This test can only run on iOS 13.0+, macOS 10.15+, tvOS 13.0+ or watchOS 6.0+")
+        }
         let httpClient = HTTPClient(adaptor: StubAdaptor(result: .failure(SampleError())))
         assert(httpClient.adaptor.calledCount == 0)
         


### PR DESCRIPTION
- ~~Updated to use `XCTSkip`.~~
  - The `async` function could not be used without the `@available` annotation because the `macos-latest` in GitHub Actions is still less than macOS 12.
- Updated to use raw strings.