### PR TITLE
Updated to validate response with content types

### DIFF
--- a/Sources/Firework/APIRequest.swift
+++ b/Sources/Firework/APIRequest.swift
@@ -10,11 +10,14 @@ import Foundation
 
 public protocol APIRequest {
     associatedtype StatusCodes: Sequence where StatusCodes.Element == Int
+    associatedtype ContentTypes: Sequence where ContentTypes.Element == String
+    
     static var httpMethod: HTTPMethod { get }
     var endpoint: Endpoint { get }
     var headers: HTTPHeaders? { get }
     var queryItems: [URLQueryItem]? { get }
     var acceptableStatusCodes: StatusCodes { get }
+    var acceptableContentTypes: ContentTypes { get }
 }
 
 public extension APIRequest {
@@ -22,6 +25,10 @@ public extension APIRequest {
     var headers: HTTPHeaders? { nil }
     var queryItems: [URLQueryItem]? { nil }
     var acceptableStatusCodes: Range<Int> { 200..<400 }
+    
+    var acceptableContentTypes: [String] {
+        headers?["Accept"]?.components(separatedBy: ",") ?? ["*/*"]
+    }
     
     /// URL component to pass to Alamofire.
     var urlComponents: URLComponents {

--- a/Sources/Firework/HTTPClient/AFClient.swift
+++ b/Sources/Firework/HTTPClient/AFClient.swift
@@ -35,6 +35,7 @@ public struct AlamofireAdaptor: HTTPClientAdaptor {
                    encoding: JSONEncoding.default,
                    headers: request.headers)
             .validate(statusCode: request.acceptableStatusCodes)
+            .validate(contentType: request.acceptableContentTypes)
     }
 }
 

--- a/Tests/FireworkTests/APIRequestTests.swift
+++ b/Tests/FireworkTests/APIRequestTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import Alamofire
 @testable import Firework
 
 final class APIRequestTests: XCTestCase {
@@ -20,6 +21,7 @@ final class APIRequestTests: XCTestCase {
         let request = TestGETRequest()
         XCTAssertNil(request.headers)
         XCTAssertEqual(request.acceptableStatusCodes, 200..<400)
+        XCTAssertEqual(request.acceptableContentTypes, ["*/*"])
         
         let urlComponents = request.urlComponents
         XCTAssertEqual(urlComponents.url, URL(string: "https://www.sample.com")!)
@@ -37,6 +39,7 @@ final class APIRequestTests: XCTestCase {
         let request = TestPOSTRequest()
         XCTAssertNil(request.headers)
         XCTAssertEqual(request.acceptableStatusCodes, 200..<400)
+        XCTAssertEqual(request.acceptableContentTypes, ["*/*"])
         
         let urlComponents = request.urlComponents
         XCTAssertEqual(urlComponents.url, URL(string: "https://www.sample.com")!)
@@ -54,6 +57,7 @@ final class APIRequestTests: XCTestCase {
         let request = TestPUTRequest()
         XCTAssertNil(request.headers)
         XCTAssertEqual(request.acceptableStatusCodes, 200..<400)
+        XCTAssertEqual(request.acceptableContentTypes, ["*/*"])
         
         let urlComponents = request.urlComponents
         XCTAssertEqual(urlComponents.url, URL(string: "https://www.sample.com")!)
@@ -71,6 +75,7 @@ final class APIRequestTests: XCTestCase {
         let request = TestPATCHRequest()
         XCTAssertNil(request.headers)
         XCTAssertEqual(request.acceptableStatusCodes, 200..<400)
+        XCTAssertEqual(request.acceptableContentTypes, ["*/*"])
         
         let urlComponents = request.urlComponents
         XCTAssertEqual(urlComponents.url, URL(string: "https://www.sample.com")!)
@@ -87,10 +92,22 @@ final class APIRequestTests: XCTestCase {
         let request = TestDELETERequest()
         XCTAssertNil(request.headers)
         XCTAssertEqual(request.acceptableStatusCodes, 200..<400)
+        XCTAssertEqual(request.acceptableContentTypes, ["*/*"])
         
         let urlComponents = request.urlComponents
         XCTAssertEqual(urlComponents.url, URL(string: "https://www.sample.com")!)
         XCTAssertNil(urlComponents.queryItems)
+    }
+    
+    func testDefaultAcceptableContentTypes() {
+        struct TestRequest: GETRequest {
+            var endpoint: Endpoint { "https://www.sample.com" }
+            var headers: HTTPHeaders? {
+                ["Accept": "text/html,application/json"]
+            }
+        }
+        let request = TestRequest()
+        XCTAssertEqual(request.acceptableContentTypes, ["text/html", "application/json"])
     }
     
     func testURLComponentsWithQueries() {


### PR DESCRIPTION
# Features
- Added `acceptableContentTypes` to `APIRequest`.

# Changes
- Changed to validate response with content types.