### PR TITLE
Renamed protocols

### DIFF
--- a/Sources/Firework/HTTPClient/AFClient.swift
+++ b/Sources/Firework/HTTPClient/AFClient.swift
@@ -12,23 +12,23 @@ import Foundation
 
 public struct AlamofireAdaptor: HTTPClientAdaptor {
     
-    public func send<Request: APIRequest>(_ request: Request,
-                                          receiveOn queue: DispatchQueue = .main,
-                                          completion: @escaping (Result<Data?, AFError>) -> Void) {
+    public func send(_ request: some HTTPRequest,
+                     receiveOn queue: DispatchQueue = .main,
+                     completion: @escaping (Result<Data?, AFError>) -> Void) {
         makeDataRequest(from: request).response(queue: queue) { response in
             completion(response.result)
         }
     }
     
-    public func send<Request: APIRequest>(_ request: Request,
-                                          receiveOn queue: DispatchQueue = .main,
-                                          completion: @escaping (Result<Data, AFError>) -> Void) {
+    public func send(_ request: some HTTPRequest,
+                     receiveOn queue: DispatchQueue = .main,
+                     completion: @escaping (Result<Data, AFError>) -> Void) {
         makeDataRequest(from: request).responseData(queue: queue) { response in
             completion(response.result)
         }
     }
     
-    private func makeDataRequest<Request: APIRequest>(from request: Request) -> DataRequest {
+    private func makeDataRequest<Request: HTTPRequest>(from request: Request) -> DataRequest {
         AF.request(request.urlComponents,
                    method: Request.httpMethod,
                    parameters: (request as? Postable)?.body,

--- a/Sources/Firework/HTTPClient/AFClient.swift
+++ b/Sources/Firework/HTTPClient/AFClient.swift
@@ -31,7 +31,7 @@ public struct AlamofireAdaptor: HTTPClientAdaptor {
     private func makeDataRequest<Request: HTTPRequest>(from request: Request) -> DataRequest {
         AF.request(request.urlComponents,
                    method: Request.httpMethod,
-                   parameters: (request as? Postable)?.body,
+                   parameters: (request as? HTTPBodySendable)?.body,
                    encoding: JSONEncoding.default,
                    headers: request.headers)
             .validate(statusCode: request.acceptableStatusCodes)

--- a/Sources/Firework/HTTPClient/HTTPClient.swift
+++ b/Sources/Firework/HTTPClient/HTTPClient.swift
@@ -31,11 +31,11 @@ public struct HTTPClient<Adaptor: HTTPClientAdaptor> {
     
     /// Send a request and receive the simple response.
     /// - Parameters:
-    ///   - request: An instance of the request type that conforms to the ``APIRequest`` protocol.
+    ///   - request: An instance of the request type that conforms to the ``HTTPRequest`` protocol.
     ///   - queue: The queue on which the completion handler is called. The default is `.main`.
     ///   - completion: The handler to be executed once the request has finished.
     @inlinable
-    public func send<Request: APIRequest>(_ request: Request,
+    public func send<Request: HTTPRequest>(_ request: Request,
                                           receiveOn queue: DispatchQueue = .main,
                                           completion: @escaping (Result<Data?, Adaptor.Failure>) -> Void) {
         adaptor.send(request, receiveOn: queue, completion: completion)
@@ -43,10 +43,10 @@ public struct HTTPClient<Adaptor: HTTPClientAdaptor> {
     
     /// Send a request and receive the simple response asynchronously.
     /// - Parameters:
-    ///   - request: An instance of the request type that conforms to the ``APIRequest`` protocol.
+    ///   - request: An instance of the request type that conforms to the ``HTTPRequest`` protocol.
     /// - Returns: The response data.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-    public func send<Request: APIRequest>(_ request: Request) async throws -> Data? {
+    public func send<Request: HTTPRequest>(_ request: Request) async throws -> Data? {
         try await withCheckedThrowingContinuation { continuation in
             adaptor.send(request, receiveOn: .main, completion: continuation.resume(with:))
         }

--- a/Sources/Firework/HTTPClient/HTTPClientAdaptor.swift
+++ b/Sources/Firework/HTTPClient/HTTPClientAdaptor.swift
@@ -10,20 +10,20 @@ import Foundation
 public protocol HTTPClientAdaptor {
     associatedtype Failure: Error
     
-    func send<Request: APIRequest>(_ request: Request,
-                                   receiveOn queue: DispatchQueue,
-                                   completion: @escaping (Result<Data?, Failure>) -> Void)
+    func send(_ request: some HTTPRequest,
+              receiveOn queue: DispatchQueue,
+              completion: @escaping (Result<Data?, Failure>) -> Void)
     
-    func send<Request: APIRequest>(_ request: Request,
-                                   receiveOn queue: DispatchQueue,
-                                   completion: @escaping (Result<Data, Failure>) -> Void)
+    func send(_ request: some HTTPRequest,
+              receiveOn queue: DispatchQueue,
+              completion: @escaping (Result<Data, Failure>) -> Void)
 }
 
 public extension HTTPClientAdaptor {
     
-    func send<Request: APIRequest>(_ request: Request,
-                                   receiveOn queue: DispatchQueue,
-                                   completion: @escaping (Result<Data?, Failure>) -> Void) {
+    func send(_ request: some HTTPRequest,
+              receiveOn queue: DispatchQueue,
+              completion: @escaping (Result<Data?, Failure>) -> Void) {
         send(request, receiveOn: queue) { (result: Result<Data, Failure>) in
             completion(result.map { $0 as Data? })
         }

--- a/Sources/Firework/HTTPRequest.swift
+++ b/Sources/Firework/HTTPRequest.swift
@@ -43,7 +43,10 @@ public extension HTTPRequest {
     }
 }
 
-public protocol Postable {
+@available(*, unavailable, renamed: "HTTPBodySendable")
+public protocol Postable {}
+
+public protocol HTTPBodySendable {
     var body: [String: Any] { get }
 }
 
@@ -57,7 +60,7 @@ public extension GETRequest {
 
 // MARK: - POSTRequest
 
-public protocol POSTRequest: HTTPRequest, Postable {}
+public protocol POSTRequest: HTTPRequest, HTTPBodySendable {}
 
 public extension POSTRequest {
     static var httpMethod: HTTPMethod { .post }
@@ -65,7 +68,7 @@ public extension POSTRequest {
 
 // MARK: - PUTRequest
 
-public protocol PUTRequest: HTTPRequest, Postable {}
+public protocol PUTRequest: HTTPRequest, HTTPBodySendable {}
 
 public extension PUTRequest {
     static var httpMethod: HTTPMethod { .put }
@@ -73,7 +76,7 @@ public extension PUTRequest {
 
 // MARK: - PATCHRequest
 
-public protocol PATCHRequest: HTTPRequest, Postable {}
+public protocol PATCHRequest: HTTPRequest, HTTPBodySendable {}
 
 public extension PATCHRequest {
     static var httpMethod: HTTPMethod { .patch }

--- a/Sources/Firework/HTTPRequest.swift
+++ b/Sources/Firework/HTTPRequest.swift
@@ -1,5 +1,5 @@
 //
-//  APIRequest.swift
+//  HTTPRequest.swift
 //  
 //
 //  Created by Yusaku Nishi on 2020/10/23.
@@ -8,7 +8,10 @@
 import Alamofire
 import Foundation
 
-public protocol APIRequest {
+@available(*, unavailable, renamed: "HTTPRequest")
+public protocol APIRequest {}
+
+public protocol HTTPRequest {
     associatedtype StatusCodes: Sequence where StatusCodes.Element == Int
     associatedtype ContentTypes: Sequence where ContentTypes.Element == String
     
@@ -20,7 +23,7 @@ public protocol APIRequest {
     var acceptableContentTypes: ContentTypes { get }
 }
 
-public extension APIRequest {
+public extension HTTPRequest {
     
     var headers: HTTPHeaders? { nil }
     var queryItems: [URLQueryItem]? { nil }
@@ -46,7 +49,7 @@ public protocol Postable {
 
 // MARK: - GETRequest
 
-public protocol GETRequest: APIRequest {}
+public protocol GETRequest: HTTPRequest {}
 
 public extension GETRequest {
     static var httpMethod: HTTPMethod { .get }
@@ -54,7 +57,7 @@ public extension GETRequest {
 
 // MARK: - POSTRequest
 
-public protocol POSTRequest: APIRequest, Postable {}
+public protocol POSTRequest: HTTPRequest, Postable {}
 
 public extension POSTRequest {
     static var httpMethod: HTTPMethod { .post }
@@ -62,7 +65,7 @@ public extension POSTRequest {
 
 // MARK: - PUTRequest
 
-public protocol PUTRequest: APIRequest, Postable {}
+public protocol PUTRequest: HTTPRequest, Postable {}
 
 public extension PUTRequest {
     static var httpMethod: HTTPMethod { .put }
@@ -70,7 +73,7 @@ public extension PUTRequest {
 
 // MARK: - PATCHRequest
 
-public protocol PATCHRequest: APIRequest, Postable {}
+public protocol PATCHRequest: HTTPRequest, Postable {}
 
 public extension PATCHRequest {
     static var httpMethod: HTTPMethod { .patch }
@@ -78,7 +81,7 @@ public extension PATCHRequest {
 
 // MARK: - DELETERequest
 
-public protocol DELETERequest: APIRequest {}
+public protocol DELETERequest: HTTPRequest {}
 
 public extension DELETERequest {
     static var httpMethod: HTTPMethod { .delete }
@@ -86,7 +89,7 @@ public extension DELETERequest {
 
 // MARK: - DecodingRequest
 
-public protocol DecodingRequest: APIRequest {
+public protocol DecodingRequest: HTTPRequest {
     associatedtype Response: Decodable
     
     /// A decoder to be used when decoding to `Response`.

--- a/Tests/FireworkTests/HTTPClientTests.swift
+++ b/Tests/FireworkTests/HTTPClientTests.swift
@@ -19,9 +19,9 @@ final class HTTPClientTests: XCTestCase {
             self.result = result
         }
         
-        func send<Request: APIRequest>(_ request: Request,
-                                       receiveOn queue: DispatchQueue = .main,
-                                       completion: @escaping (Result<Data, Error>) -> Void) {
+        func send(_ request: some HTTPRequest,
+                  receiveOn queue: DispatchQueue = .main,
+                  completion: @escaping (Result<Data, Error>) -> Void) {
             calledCount += 1
             queue.async { [unowned self] in
                 completion(result)

--- a/Tests/FireworkTests/HTTPRequestTests.swift
+++ b/Tests/FireworkTests/HTTPRequestTests.swift
@@ -1,5 +1,5 @@
 //
-//  APIRequestTests.swift
+//  HTTPRequestTests.swift
 //  
 //
 //  Created by Yusaku Nishi on 2021/04/19.
@@ -9,7 +9,7 @@ import XCTest
 import Alamofire
 @testable import Firework
 
-final class APIRequestTests: XCTestCase {
+final class HTTPRequestTests: XCTestCase {
     
     func testGETRequestProperties() {
         struct TestGETRequest: GETRequest {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,8 @@
 coverage:
   status:
+    patch:
+      default:
+        informational: true
     project:
       default:
         threshold: 10%


### PR DESCRIPTION
# Changes
- Renamed `APIRequest` to `HTTPRequest`.
- Renamed `Postable` to `HTTPBodySendable`.

# Maintenance
- Refactored generic functions to use `some` keyword for arguments.