### PR TITLE
Prepare for Swift 6

### DIFF
--- a/Sources/Firework/Endpoint.swift
+++ b/Sources/Firework/Endpoint.swift
@@ -6,7 +6,7 @@
 //
 
 /// An API endpoint representation.
-public struct Endpoint: Hashable {
+public struct Endpoint: Hashable, Sendable {
     
     public let urlString: String
     

--- a/Sources/Firework/HTTPClient/AFClient.swift
+++ b/Sources/Firework/HTTPClient/AFClient.swift
@@ -31,7 +31,7 @@ public struct AlamofireAdaptor: HTTPClientAdaptor {
     private func makeDataRequest<Request: HTTPRequest>(from request: Request) -> DataRequest {
         AF.request(request.urlComponents,
                    method: Request.httpMethod,
-                   parameters: (request as? HTTPBodySendable)?.body,
+                   parameters: (request as? any HTTPBodySendable)?.body,
                    encoding: JSONEncoding.default,
                    headers: request.headers)
             .validate(statusCode: request.acceptableStatusCodes)

--- a/Sources/Firework/HTTPClient/AFClient.swift
+++ b/Sources/Firework/HTTPClient/AFClient.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - AlamofireAdaptor -
 
-public struct AlamofireAdaptor: HTTPClientAdaptor {
+public struct AlamofireAdaptor: HTTPClientAdaptor, Sendable {
     
     public func send(_ request: some HTTPRequest,
                      receiveOn queue: DispatchQueue = .main,

--- a/Sources/Firework/HTTPClient/HTTPClient.swift
+++ b/Sources/Firework/HTTPClient/HTTPClient.swift
@@ -59,7 +59,7 @@ public struct HTTPClient<Adaptor: HTTPClientAdaptor> {
     ///   - decodingCompletion: The handler to be executed once the request and decoding has finished.
     public func send<Request: DecodingRequest>(_ request: Request,
                                                receiveOn queue: DispatchQueue = .main,
-                                               decodingCompletion: @escaping (Result<Request.Response, Error>) -> Void) {
+                                               decodingCompletion: @escaping (Result<Request.Response, any Error>) -> Void) {
         adaptor.send(request, receiveOn: queue) { (result: Result<Data, Adaptor.Failure>) in
             decodingCompletion(Result {
                 let decoder = Request.preferredJSONDecoder ?? configuration.defaultJSONDecoder

--- a/Sources/Firework/HTTPClient/HTTPClient.swift
+++ b/Sources/Firework/HTTPClient/HTTPClient.swift
@@ -75,7 +75,7 @@ public struct HTTPClient<Adaptor: HTTPClientAdaptor> {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     public func send<Request: DecodingRequest>(_ request: Request) async throws -> Request.Response {
         try await withCheckedThrowingContinuation { continuation in
-            send(request, decodingCompletion: continuation.resume(with:))
+            send(request, receiveOn: .main, decodingCompletion: continuation.resume(with:))
         }
     }
 }

--- a/Tests/FireworkTests/HTTPClientTests.swift
+++ b/Tests/FireworkTests/HTTPClientTests.swift
@@ -12,16 +12,16 @@ final class HTTPClientTests: XCTestCase {
     
     private final class StubAdaptor: HTTPClientAdaptor {
         
-        let result: Result<Data, Error>
+        let result: Result<Data, any Error>
         private(set) var calledCount = 0
         
-        init(result: Result<Data, Error>) {
+        init(result: Result<Data, any Error>) {
             self.result = result
         }
         
         func send(_ request: some HTTPRequest,
                   receiveOn queue: DispatchQueue = .main,
-                  completion: @escaping (Result<Data, Error>) -> Void) {
+                  completion: @escaping (Result<Data, any Error>) -> Void) {
             calledCount += 1
             queue.async { [unowned self] in
                 completion(result)


### PR DESCRIPTION
# Features
- Updated `Endpoint` and `AlamofireAdaptor` to conform to `Sendable`.

# Maintenance
- Updated to use `any` keyword.