### PR TITLE
Updated `HTTPClient.send(_:)` to be marked with `@discardableResult`

### DIFF
--- a/Sources/Firework/HTTPClient/HTTPClient.swift
+++ b/Sources/Firework/HTTPClient/HTTPClient.swift
@@ -39,9 +39,9 @@ public struct HTTPClient<Adaptor: HTTPClientAdaptor> {
     ///   - queue: The queue on which the completion handler is called. The default is `.main`.
     ///   - completion: The handler to be executed once the request has finished.
     @inlinable
-    public func send<Request: HTTPRequest>(_ request: Request,
-                                          receiveOn queue: DispatchQueue = .main,
-                                          completion: @escaping (Result<Data?, Adaptor.Failure>) -> Void) {
+    public func send(_ request: some HTTPRequest,
+                     receiveOn queue: DispatchQueue = .main,
+                     completion: @escaping (Result<Data?, Adaptor.Failure>) -> Void) {
         adaptor.send(request, receiveOn: queue, completion: completion)
     }
     
@@ -51,7 +51,7 @@ public struct HTTPClient<Adaptor: HTTPClientAdaptor> {
     /// - Returns: The response data.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     @discardableResult
-    public func send<Request: HTTPRequest>(_ request: Request) async throws -> Data? {
+    public func send(_ request: some HTTPRequest) async throws -> Data? {
         try await withCheckedThrowingContinuation { continuation in
             adaptor.send(request, receiveOn: .main, completion: continuation.resume(with:))
         }

--- a/Sources/Firework/HTTPClient/HTTPClient.swift
+++ b/Sources/Firework/HTTPClient/HTTPClient.swift
@@ -50,6 +50,7 @@ public struct HTTPClient<Adaptor: HTTPClientAdaptor> {
     ///   - request: An instance of the request type that conforms to the ``HTTPRequest`` protocol.
     /// - Returns: The response data.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @discardableResult
     public func send<Request: HTTPRequest>(_ request: Request) async throws -> Data? {
         try await withCheckedThrowingContinuation { continuation in
             adaptor.send(request, receiveOn: .main, completion: continuation.resume(with:))

--- a/Tests/FireworkTests/HTTPClientTests.swift
+++ b/Tests/FireworkTests/HTTPClientTests.swift
@@ -98,7 +98,7 @@ final class HTTPClientTests: XCTestCase {
         assert(httpClient.adaptor.calledCount == 0)
         
         do {
-            let _ = try await httpClient.send(SampleGETRequest())
+            try await httpClient.send(SampleGETRequest())
             XCTFail("The request should fail.")
         } catch {
             XCTAssert(error is SampleError)


### PR DESCRIPTION
# Changes
- Updated `HTTPClient.send(_:)` to be marked with `@discardableResult`.
- Changed to use `some` keyword for generic functions.