### PR TITLE
Updated `HTTPClient.init(configuration:)` to have the default argument

### DIFF
--- a/Sources/Firework/HTTPClient.swift
+++ b/Sources/Firework/HTTPClient.swift
@@ -25,6 +25,7 @@ public final class HTTPClientConfiguration {
     /// implement the `preferredJSONDecoder` property in the request type that conforms to the ``DecodingRequest`` protocol.
     public lazy var defaultJSONDecoder = JSONDecoder()
     
+    /// Creates an ``HTTPClientConfiguration`` instance.
     public init() {}
 }
 
@@ -45,6 +46,8 @@ public struct HTTPClient {
     
     // MARK: - Initializers
     
+    /// Creates an ``HTTPClient`` instance.
+    /// - Parameter configuration: A configuration used for HTTP communication.
     public init(configuration: HTTPClientConfiguration = .init()) {
         self.configuration = configuration
         self.session = Session(configuration: configuration.urlSession)

--- a/Sources/Firework/HTTPClient.swift
+++ b/Sources/Firework/HTTPClient.swift
@@ -45,7 +45,7 @@ public struct HTTPClient {
     
     // MARK: - Initializers
     
-    public init(configuration: HTTPClientConfiguration) {
+    public init(configuration: HTTPClientConfiguration = .init()) {
         self.configuration = configuration
         self.session = Session(configuration: configuration.urlSession)
     }


### PR DESCRIPTION
# Features
- Updated `HTTPClient.init(configuration:)` to have the default argument.